### PR TITLE
Add support for TypeScript declarationMap

### DIFF
--- a/src/extractTypes.js
+++ b/src/extractTypes.js
@@ -1,4 +1,3 @@
-import { existsSync } from "fs"
 import { dirname, join } from "path"
 import {
   createProgram,
@@ -34,15 +33,14 @@ function compile(fileNames, options, verbose) {
   }
 }
 
-export default function extractTypes({ input, root, output, verbose }) {
-  const tsConfig = join(root, "tsconfig.json")
-  const configured = existsSync(tsConfig) && require(tsConfig).compilerOptions
-
+export default function extractTypes({ input, root, output, verbose, tsConfig }) {
   const defaults = {
     allowSyntheticDefaultImports: true,
     esModuleInterop: true,
     target: ScriptTarget.ES2017,
   }
+
+  const configured = tsConfig && tsConfig.compilerOptions || {}
 
   const enforced = {
     declaration: true,

--- a/src/extractTypes.js
+++ b/src/extractTypes.js
@@ -1,12 +1,11 @@
 import { existsSync } from "fs"
-import { merge } from "lodash"
 import { dirname, join } from "path"
 import {
   createProgram,
   flattenDiagnosticMessageText,
   getPreEmitDiagnostics,
   ModuleResolutionKind,
-  ScriptTarget
+  ScriptTarget,
 } from "typescript"
 
 // Compiler based on code shown in the official docs:
@@ -53,7 +52,11 @@ export default function extractTypes({ input, root, output, verbose }) {
     moduleResolution: ModuleResolutionKind.NodeJs,
   }
 
-  const compilerOptions = merge(defaults, configured, enforced)
+  const compilerOptions = {
+    ...defaults,
+    ...configured,
+    ...enforced,
+  }
 
   if (verbose) {
     console.log(

--- a/src/getTasks.js
+++ b/src/getTasks.js
@@ -12,7 +12,8 @@ export default function getTasks({
   entries,
   output,
   limit,
-  exec
+  exec,
+  tsConfig,
 }) {
   if (!output.main && !entries.binaries) {
     console.warn(chalk.red.bold("  - Missing `main` or `bin` entry in `package.json`!"))
@@ -98,7 +99,8 @@ export default function getTasks({
       input: entries.library,
       target: "lib",
       format: "tsc",
-      output: output.types
+      output: output.types,
+      tsConfig,
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 /* eslint-disable complexity, max-statements, max-depth */
-import { dirname, extname, relative, resolve, sep } from "path"
 import chalk from "chalk"
-
 import figures from "figures"
+import { existsSync } from "fs"
 import notifier from "node-notifier"
-import stackTrace from "stack-trace"
 import terminalSpinner from "ora"
+import { dirname, extname, relative, resolve, sep } from "path"
 import { rollup, watch } from "rollup"
+import stackTrace from "stack-trace"
 
 import extractTypes from "./extractTypes"
 import getBanner from "./getBanner"
@@ -30,13 +30,16 @@ function notify(options, message) {
 
 export default async function index(opts) {
   const pkg = require(resolve(opts.root, "package.json"))
+  const tsConfigFile = resolve(opts.root, "tsconfig.json")
+  const tsConfig = existsSync(tsConfigFile) ? require(tsConfigFile) : undefined
 
   const options = {
     ...opts,
     name: pkg.name || dirname(opts.root),
     version: pkg.version || "0.0.0",
     banner: getBanner(pkg),
-    output: getOutputMatrix(opts, pkg)
+    output: getOutputMatrix(opts, pkg),
+    tsConfig,
   }
 
   options.entries = getEntries(options)
@@ -158,7 +161,7 @@ function handleError(error, progress) {
 }
 
 function bundleTypes(options) {
-  if ([ ".ts", ".tsx" ].includes(extname(options.input))) {
+  if ([".ts", ".tsx"].includes(extname(options.input))) {
     const start = process.hrtime()
 
     let progress = null

--- a/test/typescript/__snapshots__/index.test.js.snap
+++ b/test/typescript/__snapshots__/index.test.js.snap
@@ -253,8 +253,10 @@ export declare class MyClass {
     helper(x: string): void;
 }
 export declare const setValues: (values: FormValues) => void;
-"
+//# sourceMappingURL=index.d.ts.map"
 `;
+
+exports[`Publish Test File via Typescript: types-main-map 1`] = `"{\\"version\\":3,\\"file\\":\\"index.d.ts\\",\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"../src/index.tsx\\"],\\"names\\":[],\\"mappings\\":\\"AASA,OAAO,EAAE,UAAU,EAAa,MAAM,SAAS,CAAA;AAwC/C,qBAAa,OAAO;;IAOlB,OAAO,aAEN;IAED,MAAM,CAAC,CAAC,EAAE,MAAM;CAGjB;AAkBD,eAAO,MAAM,SAAS,8BAErB,CAAA\\"}"`;
 
 exports[`Publish Test File via Typescript: types-sub 1`] = `
 "/**
@@ -264,7 +266,7 @@ export interface FormValues {
     [field: string]: any;
 }
 export declare const something = 42;
-"
+//# sourceMappingURL=types.d.ts.map"
 `;
 
 exports[`Publish Test File via Typescript: umd 1`] = `

--- a/test/typescript/index.test.js
+++ b/test/typescript/index.test.js
@@ -33,4 +33,7 @@ test("Publish Test File via Typescript", async () => {
   expect(
     await lazyRead(resolve(__dirname, "dist/types.d.ts"), "utf8")
   ).toMatchSnapshot("types-sub")
+  expect(
+    await lazyRead(resolve(__dirname, "dist/index.d.ts.map"), "utf8")
+  ).toMatchSnapshot("types-main-map")
 })

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
Adds support for declaration maps, which allows jumping to TS sources.

Resolves https://github.com/sebastian-software/preppy/issues/2.

Implementing this requires introducing a place to configure TS options. For babel, this is the project's local babel config. So it makes sense to also respect the local tsconfig for TS-related work.

The current options don't change, but they are now split into

- "defaults" (things that are optional)
- "configured" (pulled from tsconfig)
- "enforced" (things that don't make sense any other way).

Adds a declarationMap snapshot test.