### PR TITLE
Use typescript to read extended tsconfig options

### DIFF
--- a/src/extractTypes.js
+++ b/src/extractTypes.js
@@ -49,7 +49,7 @@ export default function extractTypes({ input, root, output, verbose, tsConfig })
     target: ts.ScriptTarget.ES2017
   }
 
-  const configured = tsConfig ? tsConfig.compilerOptions : {}
+  const configured = tsConfig || {}
 
   // Make sure that user configured paths are absolute.
   // Otherwise TypeScript as of v3.3 and v3.4 might crash.

--- a/src/extractTypes.js
+++ b/src/extractTypes.js
@@ -1,4 +1,4 @@
-import { dirname, isAbsolute, join } from "path"
+import { dirname, join } from "path"
 
 /* eslint-disable id-length */
 let ts
@@ -35,14 +35,6 @@ function compile(fileNames, options, verbose) {
 export default function extractTypes({ input, root, output, verbose, tsConfig }) {
   const outputDir = dirname(output)
 
-  function makeAbsolute(anyPath) {
-    if (anyPath && !isAbsolute(anyPath)) {
-      return join(root, outputDir)
-    }
-
-    return anyPath
-  }
-
   const defaults = {
     allowSyntheticDefaultImports: true,
     esModuleInterop: true,
@@ -53,11 +45,12 @@ export default function extractTypes({ input, root, output, verbose, tsConfig })
 
   // Make sure that user configured paths are absolute.
   // Otherwise TypeScript as of v3.3 and v3.4 might crash.
-  configured.rootDir = makeAbsolute(configured.rootDir)
+  configured.declarationDir = ts.getNormalizedAbsolutePath(configured.declarationDir)
+  configured.outDir = ts.getNormalizedAbsolutePath(configured.outDir)
+  configured.rootDir = ts.getNormalizedAbsolutePath(configured.rootDir)
   if (configured.rootDirs) {
-    configured.rootDirs = configured.rootDirs.map(makeAbsolute)
+    configured.rootDirs = configured.rootDirs.map(ts.getNormalizedAbsolutePath)
   }
-  configured.outDir = makeAbsolute(configured.outDir)
 
   const enforced = {
     declaration: true,

--- a/src/getTsCompilerOptions.js
+++ b/src/getTsCompilerOptions.js
@@ -5,12 +5,16 @@ try {
 } catch(importError) {}
 
 export function getTsCompilerOptions(opts) {
+  if (!ts) {
+    return
+  }
+
   const { verbose } = opts
   const file = ts.findConfigFile(opts.root, ts.sys.fileExists)
 
   if (!file) {
     if (verbose) {
-      console.error("No tsconfig found in", opts.root)
+      console.log("No tsconfig found in", opts.root)
     }
     return
   }

--- a/src/getTsCompilerOptions.js
+++ b/src/getTsCompilerOptions.js
@@ -14,12 +14,19 @@ export function getTsCompilerOptions(opts) {
   const readResult = ts.readConfigFile(file, ts.sys.readFile)
 
   if (readResult.error) {
-    console.error("Error reading tsconfig:", readResult.error)
+    console.error("Error reading tsconfig:", readResult.error.messageText)
     return
   }
 
   const basePath = ts.getDirectoryPath(file)
   const config = ts.parseJsonConfigFileContent(readResult.config, ts.sys, basePath)
+
+  if (config.errors && config.errors.length) {
+    config.errors.forEach(error => {
+      console.error("Error reading tsconfig:", error.messageText)
+    })
+    return
+  }
 
   return config.options
 }

--- a/src/getTsCompilerOptions.js
+++ b/src/getTsCompilerOptions.js
@@ -1,4 +1,8 @@
-import ts from "typescript"
+/* eslint-disable id-length */
+let ts
+try {
+  ts = require("typescript")
+} catch(importError) {}
 
 export function getTsCompilerOptions(opts) {
   const { verbose } = opts

--- a/src/getTsCompilerOptions.js
+++ b/src/getTsCompilerOptions.js
@@ -1,0 +1,25 @@
+import ts from "typescript"
+
+export function getTsCompilerOptions(opts) {
+  const { verbose } = opts
+  const file = ts.findConfigFile(opts.root, ts.sys.fileExists)
+
+  if (!file) {
+    if (verbose) {
+      console.error("No tsconfig found in", opts.root)
+    }
+    return
+  }
+
+  const readResult = ts.readConfigFile(file, ts.sys.readFile)
+
+  if (readResult.error) {
+    console.error("Error reading tsconfig:", readResult.error)
+    return
+  }
+
+  const basePath = ts.getDirectoryPath(file)
+  const config = ts.parseJsonConfigFileContent(readResult.config, ts.sys, basePath)
+
+  return config.options
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import getRollupOutputOptions from "./getRollupOutputOptions"
 import getTasks from "./getTasks"
 import { formatDuration } from "./progressPlugin"
 import { readJSON } from "./file"
+import { getTsCompilerOptions } from "./getTsCompilerOptions"
 
 function notify(options, message) {
   notifier.notify({
@@ -30,10 +31,6 @@ function notify(options, message) {
 
 export default async function index(opts) {
   const pkg = await readJSON(resolve(opts.root, "package.json"))
-  let tsConfig
-  try {
-    tsConfig = await readJSON(resolve(opts.root, "tsconfig.json"))
-  } catch (tsError) {}
 
   const options = {
     ...opts,
@@ -41,7 +38,7 @@ export default async function index(opts) {
     version: pkg.version || "0.0.0",
     banner: getBanner(pkg),
     output: getOutputMatrix(opts, pkg),
-    tsConfig
+    tsConfig: getTsCompilerOptions(opts)
   }
 
   options.entries = getEntries(options)

--- a/test/typescript/tsconfig.base.json
+++ b/test/typescript/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "declarationMap": true
-  }
+    "baseUrl": "src",
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "extends": "./tsconfig.base.json"
 }


### PR DESCRIPTION
This PR implements support for TypeScript's `tsconfig.extends` option.

The implementation uses the TypeScript API and mimics how TS reads its own config files.
[src/harness/compiler.ts#L26](https://github.com/Microsoft/TypeScript/blob/fadd95f72b5ad7f7f1cffa2b6ac82f612694462c/src/harness/compiler.ts#L26)

I've extended the test in `test/typescript` with a tsconfig that uses the extends option.

TypeScript has its own path normalization functions, so it's probably wise to use that instead. I've also added the `declarationDir` to the paths that potentially need to be mapped.