### PR TITLE
change order of plugins, to keep the `process.env` variable and not the value

### DIFF
--- a/src/getRollupInputOptions.js
+++ b/src/getRollupInputOptions.js
@@ -64,11 +64,11 @@ export default function getRollupInputOptions(options) {
       options.exec ? runPlugin() : null,
       typescriptResolvePlugin(),
       rebasePlugin(),
+      replacePlugin(variables),
       cjsPlugin({
         include: "node_modules/**",
         extensions
       }),
-      replacePlugin(variables),
       jsonPlugin(),
       babelPlugin({
         // Rollup Setting: Prefer usage of a common library of helpers


### PR DESCRIPTION
see: https://github.com/rollup/rollup-plugin-replace#usage
> Generally, you need to ensure that rollup-plugin-replace goes before other things (like rollup-plugin-commonjs) in your plugins array, so that those plugins can apply any optimisations such as dead code removal.

The order was changed in https://github.com/sebastian-software/preppy/commit/ddd2b04d6641263af251a435c1ef82e92c8a062d#diff-72a78c3c948667cb91a0413a4b756b14, since then we have the change in our bundle