### PR TITLE
fix failing binary test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7514,9 +7514,9 @@
       }
     },
     "rollup-plugin-advanced-run": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-advanced-run/-/rollup-plugin-advanced-run-1.0.1.tgz",
-      "integrity": "sha512-iE8E+KZiJVmbKC24Ji/2nVEQwJd/wP4ytD1izBGv1qw06pnH1lkVsECwC+wTXgjPJMyvfXO8Tu8K7UGwMUhtcQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-advanced-run/-/rollup-plugin-advanced-run-1.1.0.tgz",
+      "integrity": "sha512-DAPmd8ZRLHlCoTQ/44ITGZZ/CPu8pS+fJDBA7O1MIPCvlOm/AP/5UyihIcs9lIerhcAO62wWWlYfk9CDRHi6dQ=="
     },
     "rollup-plugin-babel": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ora": "^3.4.0",
     "pretty-bytes": "^5.2.0",
     "rollup": "^1.16.7",
-    "rollup-plugin-advanced-run": "^1.0.1",
+    "rollup-plugin-advanced-run": "^1.1.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-executable": "^1.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ export default async function index(opts) {
 
     return {
       successful,
-      exitCodes: await getExitMap()
+      exitCodes: exitMap
     }
   }
 

--- a/test/failing-binary/index.test.js
+++ b/test/failing-binary/index.test.js
@@ -22,7 +22,7 @@ function fixInterOSPaths(map) {
   }, {})
 }
 
-test.skip("Multi Binary from ESNext with failing binary", async () => {
+test("Multi Binary from ESNext with failing binary", async () => {
   await lazyDelete(resolve(__dirname, "./bin"))
 
   const value = await preppy({

--- a/test/failing-binary/src/cli/first.js
+++ b/test/failing-binary/src/cli/first.js
@@ -1,5 +1,1 @@
-process.stdout.write(">>>>>>>>>>>>>>>> FIRST")
-
-setTimeout(() => {
-  process.exit(1)
-}, 1000);
+process.exit(1)

--- a/test/failing-binary/src/cli/first.js
+++ b/test/failing-binary/src/cli/first.js
@@ -1,1 +1,5 @@
-process.exit(1)
+process.stdout.write(">>>>>>>>>>>>>>>> FIRST")
+
+setTimeout(() => {
+  process.exit(1)
+}, 1000);


### PR DESCRIPTION
It seems that in our test condition a file containing

`process.exit(1)`

is not always called. By adding a delay to process.exit it seems to get more relaxed and works every time.