### PR TITLE
failing watch mode

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -36,11 +36,14 @@ async function run() {
   // Call main method
   const result = await main(flags)
 
-  if (!result.successful) {
-    process.exit(1)
-  }
+  if (!flags.watch) {
+    // Only check exit code in non-watch mode
+    if (!result.successful) {
+      process.exit(1)
+    }
 
-  process.exit(0)
+    process.exit(0)
+  }
 }
 
 run()

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ export default async function index(opts) {
 
     return {
       successful,
-      exitCodes: await getExitMap()
+      exitCodes: exitMap
     }
   }
 

--- a/test/failing-binary/src/cli/first.js
+++ b/test/failing-binary/src/cli/first.js
@@ -1,1 +1,5 @@
-process.exit(1)
+process.stdout.write(">>>>>>>>>>>>>>>> FIRST")
+
+setTimeout(() => {
+  process.exit(1)
+}, 1000);


### PR DESCRIPTION
Fixes failing watch mode. There was an forced process.exit() after executed tasks.