### PR TITLE
Better output of execution results if aborted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8673,9 +8673,9 @@
       }
     },
     "rollup-plugin-advanced-run": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-advanced-run/-/rollup-plugin-advanced-run-1.1.0.tgz",
-      "integrity": "sha512-DAPmd8ZRLHlCoTQ/44ITGZZ/CPu8pS+fJDBA7O1MIPCvlOm/AP/5UyihIcs9lIerhcAO62wWWlYfk9CDRHi6dQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-advanced-run/-/rollup-plugin-advanced-run-2.0.0.tgz",
+      "integrity": "sha512-12CK/4JIPlIp8gMfMMIoC0RWpnlPFboHzOkK4b8nRxV1QLMRukMoFX4COgaBKGzzCaK5N42Jl6esRcHJjPNl9g=="
     },
     "rollup-plugin-babel": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ora": "^4.0.2",
     "pretty-bytes": "^5.3.0",
     "rollup": "^1.23.1",
-    "rollup-plugin-advanced-run": "^1.1.0",
+    "rollup-plugin-advanced-run": "^2.0.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-executable": "^1.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -107,16 +107,20 @@ export default async function index(opts) {
     // Look at exit codes
     const exitMap = await getExitMap(opts.root)
     const stream = process.stderr
-    const successful = Object.entries(exitMap).reduce((prev, current) => {
-      const [ binary, exitCode ] = current
-
+    const successful = exitMap.reduce((prev, { command, exitCode, error }) => {
       if (exitCode === 0 && !options.quiet) {
         stream.write(
-          `${logSymbols.success} Executed: ${chalk.green(binary)} ${chalk.green("succeeded")}`
+          `${logSymbols.success} Executed: ${chalk.green(command)} ${chalk.green("succeeded")}`
+        )
+      } else if (error) {
+        stream.write(
+          `${logSymbols.error} Executed: ${chalk.green(command)} ${chalk.red(
+            `aborted with error ${error.message}`
+          )}`
         )
       } else if (exitCode > 0) {
         stream.write(
-          `${logSymbols.error} Executed: ${chalk.green(binary)} ${chalk.red(
+          `${logSymbols.error} Executed: ${chalk.green(command)} ${chalk.red(
             `failed with exit code ${exitCode}`
           )}`
         )

--- a/test/failing-binary/__snapshots__/index.test.js.snap
+++ b/test/failing-binary/__snapshots__/index.test.js.snap
@@ -1,9 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Multi Binary from ESNext with failing binary 1`] = `
-Object {
-  "bin/first-cli.js": 1,
-  "bin/second-cli.js": 0,
-  "bin/third-cli.js": 0,
-}
+Array [
+  Object {
+    "command": "bin/first-cli.js",
+    "error": null,
+    "exitCode": 1,
+  },
+  Object {
+    "command": "bin/second-cli.js",
+    "error": null,
+    "exitCode": 0,
+  },
+  Object {
+    "command": "bin/third-cli.js",
+    "error": null,
+    "exitCode": 0,
+  },
+]
 `;

--- a/test/failing-binary/index.test.js
+++ b/test/failing-binary/index.test.js
@@ -11,15 +11,13 @@ const lazyDelete = pify(rimraf)
 
 jest.setTimeout(20000)
 
-function fixInterOSPaths(map) {
-  return Object.entries(map).reduce((prev, current) => {
-    const [ binary, exitCode ] = current
-
-    const fixedBinaryName = binary.replace("\\", "/")
-    prev[fixedBinaryName] = exitCode
-
-    return prev
-  }, {})
+function fixInterOSPaths(exitCodes) {
+  return exitCodes.map((item) => {
+    return {
+      ...item,
+      command: item.command.replace("\\", "/")
+    }
+  })
 }
 
 test("Multi Binary from ESNext with failing binary", async () => {

--- a/test/failing-binary/index.test.js
+++ b/test/failing-binary/index.test.js
@@ -12,12 +12,10 @@ const lazyDelete = pify(rimraf)
 jest.setTimeout(20000)
 
 function fixInterOSPaths(exitCodes) {
-  return exitCodes.map((item) => {
-    return {
-      ...item,
-      command: item.command.replace("\\", "/")
-    }
-  })
+  return exitCodes.map((item) => ({
+    ...item,
+    command: item.command.replace("\\", "/")
+  }))
 }
 
 test("Multi Binary from ESNext with failing binary", async () => {


### PR DESCRIPTION
This is an upgrade of rollup-plugin-advanced-run that has better informations if executed bundles failed to run.

This is a breaking change (await preppy().exitCodes has changed)