### PR TITLE
fix: throw error if typescript is not installed

### DIFF
--- a/src/typescriptResolvePlugin.js
+++ b/src/typescriptResolvePlugin.js
@@ -31,7 +31,7 @@ const resolveHost = {
   }
 }
 
-const extensions = new Set([ ".ts", ".tsx" ])
+const extensions = new Set([".ts", ".tsx"])
 const compilerOptions = {}
 
 export default () => ({
@@ -49,6 +49,10 @@ export default () => ({
     }
 
     const fixedImporter = importer.split("\\").join("/")
+
+    if (!ts) {
+      throw new Error("Please install package 'typescript'")
+    }
 
     const result = ts.nodeModuleNameResolver(
       importee,


### PR DESCRIPTION
If typescript package is not installed and .ts files are resolved, preppy throws an "TypeError: Cannot read property 'nodeModuleNameResolver' of undefined". This fix throws a more informative message that 'typescript' package is missing.